### PR TITLE
Remove 'packed' from structures and improve structure mismatch handling

### DIFF
--- a/mced.h
+++ b/mced.h
@@ -90,7 +90,7 @@ struct kernel_mce {
 	uint64_t ipid;		/* MCA_IPID MSR: only valid on SMCA systems */
 	uint64_t ppin;		/* Protected Processor Inventory Number */
 	uint32_t microcode;	/* Microcode revision */
-} __attribute__ ((packed));
+};
 
 /* ioctl() calls for /dev/mcelog */
 #define MCE_GET_RECORD_LEN   _IOR('M', 1, int)
@@ -120,7 +120,7 @@ struct mce {
 	uint16_t cs;		/* CPU code segment */
 	uint8_t  bank;		/* MC bank */
 	int8_t   vendor;	/* CPU vendor (enum cpu_vendor) */
-} __attribute__ ((packed));
+};
 
 /* bits from the MCi_STATUS register */
 #define MCI_STATUS_OVER		(1ULL<<62)	/* errors overflowed */


### PR DESCRIPTION
The mced code added 'packed' to its local declaration of 'struct kernel_mce'.
This structure is intended to match the kernel declaration, which has never
used that attribute, so it's not clear why mced has it.  In addition, mced
has a parallel structure called 'struct mce' (confusingly), which also has
the 'packed' attribute for no clear reason.  Remove the attribute from both.

It's not possible to keep the mced declaration and the kernel declaration
synchronized, so mced must cope.  If the the kernel's size is larger, then
we'll only use the portion that we know about.  If the kernel's size is
smaller, then we'll zero out any of our fields that the kernel doesn't
provide.